### PR TITLE
feat: add resend email support for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use [FormZero](https://github.com/BohdanPetryshyn/formzero) for your next big th
 - **Analytics Dashboard** - View submission trends and stats
 - **Export CSV** - Download all submissions in one click
 - **Spam Protection** - Proof of Work CAPTCHA and honeypot fields (coming soon)
-- **Email Notifications** - Add your [Resend](http://resend.com) API key to receive notifications (coming soon)
+- **Email Notifications** - Get notified via [Resend](https://resend.com) or SMTP when forms are submitted
 
 <br/>
 
@@ -65,6 +65,36 @@ Here's what happens when you click the button:
 4. You get a unique URL (e.g. `https://formzero.your-domain.workers.dev`) to access your dashboard
 
 Read the [Cloudflare documentation](https://developers.cloudflare.com/workers/platform/deploy-buttons/) for more details.
+
+<br/>
+
+## Email Notifications
+
+FormZero supports email notifications when forms are submitted. You can use either **Resend** (recommended) or **SMTP**.
+
+### Option 1: Resend (Recommended)
+
+[Resend](https://resend.com) is the easiest way to set up email notifications:
+
+1. Create a free account at [resend.com](https://resend.com)
+2. Generate an API key in your Resend dashboard
+3. Add `RESEND_API_KEY` to your Cloudflare Worker:
+   - Go to your Worker settings in the Cloudflare dashboard
+   - Navigate to **Settings** → **Variables and Secrets**
+   - Add `RESEND_API_KEY` as a secret with your API key
+4. Configure the notification email in each form's settings page
+
+That's it! FormZero will use Resend to send notifications to the email you configured.
+
+### Option 2: SMTP
+
+If you prefer to use your own email provider:
+
+1. Go to your form's **Settings** → **Notifications**
+2. Enter your email address and SMTP credentials
+3. FormZero auto-detects settings for Gmail, Outlook, Yahoo, and iCloud
+
+**Note**: If both Resend and SMTP are configured, Resend takes priority.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -88,13 +88,11 @@ That's it! FormZero will use Resend to send notifications to the email you confi
 
 ### Option 2: SMTP
 
-If you prefer to use your own email provider:
+If you don't have a Resend API key configured, you can use your own email provider:
 
 1. Go to your form's **Settings** → **Notifications**
 2. Enter your email address and SMTP credentials
 3. FormZero auto-detects settings for Gmail, Outlook, Yahoo, and iCloud
-
-**Note**: If both Resend and SMTP are configured, Resend takes priority.
 
 <br/>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"react-dom": "^19.2.4",
 				"react-router": "^7.13.0",
 				"recharts": "^2.15.4",
+				"resend": "^6.7.0",
 				"tailwind-merge": "^3.4.0"
 			},
 			"devDependencies": {
@@ -3747,6 +3748,19 @@
 				"win32"
 			]
 		},
+		"node_modules/@selderee/plugin-htmlparser2": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+			"integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+			"license": "MIT",
+			"dependencies": {
+				"domhandler": "^5.0.3",
+				"selderee": "^0.11.0"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
+		},
 		"node_modules/@sindresorhus/is": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -3766,6 +3780,12 @@
 			"integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
 			"dev": true,
 			"license": "CC0-1.0"
+		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT"
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
@@ -4204,6 +4224,17 @@
 			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
+			}
+		},
+		"node_modules/@zone-eu/mailsplit": {
+			"version": "5.4.8",
+			"resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+			"integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+			"license": "(MIT OR EUPL-1.1+)",
+			"dependencies": {
+				"libbase64": "1.3.0",
+				"libmime": "5.3.7",
+				"libqp": "2.1.1"
 			}
 		},
 		"node_modules/arg": {
@@ -4805,6 +4836,15 @@
 				"node": ">=4.0.0"
 			}
 		},
+		"node_modules/deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/defu": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -4834,6 +4874,61 @@
 			"dependencies": {
 				"@babel/runtime": "^7.8.7",
 				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/dotenv": {
@@ -4897,6 +4992,15 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/encoding-japanese": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+			"integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -4918,6 +5022,18 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/error-stack-parser-es": {
@@ -5033,6 +5149,12 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense"
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5129,6 +5251,66 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/html-to-text": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+			"integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+			"license": "MIT",
+			"dependencies": {
+				"@selderee/plugin-htmlparser2": "^0.11.0",
+				"deepmerge": "^4.3.1",
+				"dom-serializer": "^2.0.0",
+				"htmlparser2": "^8.0.2",
+				"selderee": "^0.11.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"entities": "^4.4.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+			"integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
@@ -5266,6 +5448,51 @@
 			"peerDependencies": {
 				"kysely": "*"
 			}
+		},
+		"node_modules/leac": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+			"integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
+		},
+		"node_modules/libbase64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+			"integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+			"license": "MIT"
+		},
+		"node_modules/libmime": {
+			"version": "5.3.7",
+			"resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+			"integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+			"license": "MIT",
+			"dependencies": {
+				"encoding-japanese": "2.2.0",
+				"iconv-lite": "0.6.3",
+				"libbase64": "1.3.0",
+				"libqp": "2.1.1"
+			}
+		},
+		"node_modules/libmime/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/libqp": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+			"integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+			"license": "MIT"
 		},
 		"node_modules/lightningcss": {
 			"version": "1.30.2",
@@ -5528,6 +5755,15 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/lodash": {
 			"version": "4.17.23",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
@@ -5573,6 +5809,33 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/mailparser": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.1.tgz",
+			"integrity": "sha512-6vHZcco3fWsDMkf4Vz9iAfxvwrKNGbHx0dV1RKVphQ/zaNY34Buc7D37LSa09jeSeybWzYcTPjhiZFxzVRJedA==",
+			"license": "MIT",
+			"dependencies": {
+				"@zone-eu/mailsplit": "5.4.8",
+				"encoding-japanese": "2.2.0",
+				"he": "1.2.0",
+				"html-to-text": "9.0.5",
+				"iconv-lite": "0.7.0",
+				"libmime": "5.3.7",
+				"linkify-it": "5.0.0",
+				"nodemailer": "7.0.11",
+				"punycode.js": "2.3.1",
+				"tlds": "1.261.0"
+			}
+		},
+		"node_modules/mailparser/node_modules/nodemailer": {
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+			"integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/mimic-response": {
@@ -5740,6 +6003,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/parseley": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+			"integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+			"license": "MIT",
+			"dependencies": {
+				"leac": "^0.6.0",
+				"peberminta": "^0.9.0"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5762,6 +6038,15 @@
 			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/peberminta": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+			"integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -5912,6 +6197,15 @@
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/rc": {
@@ -6151,6 +6445,27 @@
 				"decimal.js-light": "^2.4.1"
 			}
 		},
+		"node_modules/resend": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/resend/-/resend-6.9.1.tgz",
+			"integrity": "sha512-jFY3qPP2cith1npRXvS7PVdnhbR1CcuzHg65ty5Elv55GKiXhe+nItXuzzoOlKeYJez1iJAo2+8f6ae8sCj0iA==",
+			"license": "MIT",
+			"dependencies": {
+				"mailparser": "3.9.1",
+				"svix": "1.84.1"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@react-email/render": "*"
+			},
+			"peerDependenciesMeta": {
+				"@react-email/render": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/resolve-pkg-maps": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -6232,11 +6547,29 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
 			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
 			"license": "MIT"
+		},
+		"node_modules/selderee": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+			"integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+			"license": "MIT",
+			"dependencies": {
+				"parseley": "^0.12.0"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
 		},
 		"node_modules/semver": {
 			"version": "7.7.3",
@@ -6377,6 +6710,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6406,6 +6749,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/svix": {
+			"version": "1.84.1",
+			"resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
+			"integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
+			"license": "MIT",
+			"dependencies": {
+				"standardwebhooks": "1.0.0",
+				"uuid": "^10.0.0"
 			}
 		},
 		"node_modules/tailwind-merge": {
@@ -6488,6 +6841,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tlds": {
+			"version": "1.261.0",
+			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+			"integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+			"license": "MIT",
+			"bin": {
+				"tlds": "bin.js"
 			}
 		},
 		"node_modules/tsconfck": {
@@ -6574,6 +6936,12 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"license": "MIT"
 		},
 		"node_modules/undici": {
 			"version": "7.18.2",
@@ -6698,6 +7066,19 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
 		"node_modules/valibot": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"react-dom": "^19.2.4",
 		"react-router": "^7.13.0",
 		"recharts": "^2.15.4",
+		"resend": "^6.7.0",
 		"tailwind-merge": "^3.4.0"
 	},
 	"devDependencies": {
@@ -66,6 +67,9 @@
 		"bindings": {
 			"BETTER_AUTH_SECRET": {
 				"description": "Secret for authentication system. Use https://jwtsecrets.com or `openssl rand -hex 16` to generate a secure secret (32 characters). No need to remember it"
+			},
+			"RESEND_API_KEY": {
+				"description": "(Optional) Resend API key for email notifications. Get one free at https://resend.com. Leave empty to use SMTP instead"
 			}
 		}
 	}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,11 @@
 	"observability": {
 		"enabled": true
 	},
+	"vars": {
+		// Optional: Set via `wrangler secret put RESEND_API_KEY` or Cloudflare dashboard
+		// If set, email notifications will use Resend instead of SMTP
+		"RESEND_API_KEY": ""
+	},
 	"d1_databases": [
 		{
 			"binding": "DB",


### PR DESCRIPTION
## Summary
- Add Resend as the primary email provider for form submission notifications
- Simplified notification settings UI when Resend is enabled (no SMTP config needed)

## Test plan
- [ ] Set `RESEND_API_KEY` via Cloudflare dashboard or `wrangler secret put`
- [ ] Configure notification email in form settings
- [ ] Submit a form and verify email is received via Resend
- [ ] Without Resend key, verify SMTP flow still works