### PR TITLE
feat: add Google OAuth with domain restriction

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,1 +1,21 @@
 BETTER_AUTH_SECRET=""
+
+# Google OAuth (Optional)
+# Get these from Google Cloud Console: https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# Domain Restriction (Optional)
+# Restrict sign-up to emails from a specific domain (e.g., "example.com")
+# Note: Only secure with Google OAuth - email/password doesn't verify ownership
+ALLOWED_EMAIL_DOMAIN=""
+
+# Multi-User Mode (Optional)
+# Set to "true" to allow multiple users to sign up
+# Default: "false" (only the first user can create an account)
+MULTI_USER_ENABLED="false"
+
+# Password Authentication (Optional)
+# Set to "false" to disable email/password sign-up and login (Google OAuth only)
+# Default: "true"
+PASSWORD_AUTH_ENABLED="true"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Use [FormZero](https://github.com/BohdanPetryshyn/formzero) for your next big th
 - **Unlimited Submissions** - Receive thousands per hour
 - **Analytics Dashboard** - View submission trends and stats
 - **Export CSV** - Download all submissions in one click
+- **Google Sign-In** - Optional OAuth login with domain restriction
+- **Multi-User Mode** - Team access with configurable domain allowlist
 - **Spam Protection** - Proof of Work CAPTCHA and honeypot fields (coming soon)
 - **Email Notifications** - Add your [Resend](http://resend.com) API key to receive notifications (coming soon)
 
@@ -65,6 +67,130 @@ Here's what happens when you click the button:
 4. You get a unique URL (e.g. `https://formzero.your-domain.workers.dev`) to access your dashboard
 
 Read the [Cloudflare documentation](https://developers.cloudflare.com/workers/platform/deploy-buttons/) for more details.
+
+<br/>
+
+## Configuration
+
+### Environment Variables
+
+FormZero uses two types of configuration:
+
+**Secrets** (set via Cloudflare dashboard or `.dev.vars` for local development):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BETTER_AUTH_SECRET` | Yes | Secret key for authentication. Use [jwtsecrets.com](https://jwtsecrets.com) or `openssl rand -hex 16` |
+| `GOOGLE_CLIENT_ID` | No | Google OAuth Client ID (see [Google Sign-In Setup](#google-sign-in-setup)) |
+| `GOOGLE_CLIENT_SECRET` | No | Google OAuth Client Secret |
+| `ALLOWED_EMAIL_DOMAIN` | No | Restrict sign-up to a specific domain (e.g., `example.com`) |
+
+**Public variables** (set in `wrangler.jsonc` or override via Cloudflare dashboard):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MULTI_USER_ENABLED` | `false` | Set to `true` to allow multiple users |
+| `PASSWORD_AUTH_ENABLED` | `true` | Set to `false` to disable email/password (Google OAuth only) |
+
+Secrets should never be committed to the repository. Public variables in `wrangler.jsonc` are safe to commit and provide defaults.
+
+<br/>
+
+### Google Sign-In Setup
+
+Enable Google OAuth to allow users to sign in with their Google account. This is especially useful when combined with domain restriction for team access.
+
+#### Step 1: Create a Google Cloud Project
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
+2. Click **Select a project** → **New Project**
+3. Enter a project name (e.g., "FormZero") and click **Create**
+
+#### Step 2: Configure OAuth Consent Screen
+
+1. In the Google Cloud Console, go to **APIs & Services** → **OAuth consent screen**
+2. Select **External** (or **Internal** if using Google Workspace and want to restrict to your organization)
+3. Fill in the required fields:
+   - **App name**: FormZero (or your preferred name)
+   - **User support email**: Your email
+   - **Developer contact email**: Your email
+4. Click **Save and Continue**
+5. On the **Scopes** page, click **Add or Remove Scopes** and select:
+   - `email`
+   - `profile`
+   - `openid`
+6. Click **Save and Continue** through the remaining steps
+
+#### Step 3: Create OAuth Credentials
+
+1. Go to **APIs & Services** → **Credentials**
+2. Click **Create Credentials** → **OAuth client ID**
+3. Select **Web application**
+4. Set the **Name** (e.g., "FormZero Web Client")
+5. Under **Authorized JavaScript origins**, add:
+   - `https://your-formzero-instance.workers.dev` (your deployed URL)
+   - `http://localhost:5173` (for local development)
+6. Under **Authorized redirect URIs**, add:
+   - `https://your-formzero-instance.workers.dev/api/auth/callback/google`
+   - `http://localhost:5173/api/auth/callback/google`
+7. Click **Create**
+8. Copy the **Client ID** and **Client Secret**
+
+#### Step 4: Add Credentials to FormZero
+
+**For Cloudflare deployment:**
+1. Go to your Cloudflare dashboard → Workers & Pages → your FormZero worker
+2. Go to **Settings** → **Variables and Secrets**
+3. Add the following secrets:
+   - `GOOGLE_CLIENT_ID`: Your Google Client ID
+   - `GOOGLE_CLIENT_SECRET`: Your Google Client Secret
+
+**For local development:**
+Add to your `.dev.vars` file:
+```
+GOOGLE_CLIENT_ID="your-client-id.apps.googleusercontent.com"
+GOOGLE_CLIENT_SECRET="your-client-secret"
+```
+
+<br/>
+
+### Domain Restriction
+
+Restrict sign-up to users from a specific email domain. This is useful for team/organization access.
+
+**Example:** To only allow users with `@acme.com` emails:
+
+```
+ALLOWED_EMAIL_DOMAIN="acme.com"
+```
+
+When configured:
+- New users must have an email ending in `@acme.com` to create an account
+- Existing users can still sign in regardless of domain
+
+**Important:** Domain restriction is only secure with Google OAuth. Email/password sign-up does not verify email ownership, so users could enter any email address. If you need strict domain enforcement, use Google OAuth and consider disabling email/password sign-up.
+
+<br/>
+
+### Multi-User Mode
+
+By default, FormZero runs in single-user mode - only the first person to sign up can access the dashboard. This restriction applies to both email/password and Google OAuth sign-up.
+
+Enable multi-user mode to allow team access:
+
+```
+MULTI_USER_ENABLED="true"
+```
+
+**Recommended setup for teams:**
+1. Enable Google sign-in
+2. Set `ALLOWED_EMAIL_DOMAIN` to your company domain
+3. Set `MULTI_USER_ENABLED` to `true`
+4. Set `PASSWORD_AUTH_ENABLED` to `false` (for secure domain enforcement)
+
+This allows anyone with a company Google account to sign in and manage forms, while ensuring only verified emails from your domain can access the system.
+
+**Note:** In single-user mode with Google OAuth enabled, only the owner can sign in. If someone else tries to use Google sign-in with a different account, they will be blocked.
 
 <br/>
 

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -1,16 +1,103 @@
-import { betterAuth } from "better-auth"
+import { betterAuth, type BetterAuthOptions } from "better-auth"
 import { D1Dialect } from 'kysely-d1';
 
-export function getAuth({ database }: { database: D1Database }) {
+export interface AuthConfig {
+    database: D1Database
+    googleClientId?: string
+    googleClientSecret?: string
+    allowedEmailDomain?: string
+    multiUserEnabled?: boolean
+    passwordAuthEnabled?: boolean
+}
+
+export function getAuth({ database, googleClientId, googleClientSecret, allowedEmailDomain, multiUserEnabled, passwordAuthEnabled = true }: AuthConfig) {
+    const socialProviders: BetterAuthOptions["socialProviders"] = {}
+
+    // Only add Google provider if credentials are configured
+    if (googleClientId && googleClientSecret) {
+        socialProviders.google = {
+            clientId: googleClientId,
+            clientSecret: googleClientSecret,
+        }
+    }
+
     return betterAuth({
         database: {
            type: "sqlite",
-           dialect: new D1Dialect({ database }), 
+           dialect: new D1Dialect({ database }),
         },
         emailAndPassword: {
-            enabled: true
+            enabled: passwordAuthEnabled
+        },
+        socialProviders,
+        account: {
+            accountLinking: {
+                enabled: true,
+                trustedProviders: ["google"]
+            }
+        },
+        databaseHooks: {
+            user: {
+                create: {
+                    before: async (user) => {
+                        // Enforce single-user mode: block new users if one already exists
+                        if (!multiUserEnabled) {
+                            const result = await database
+                                .prepare("SELECT COUNT(*) as count FROM user")
+                                .first<{ count: number }>();
+
+                            if (result && result.count > 0) {
+                                throw new Error("Registration is disabled. Only one user is allowed.")
+                            }
+                        }
+
+                        // Validate email domain if restriction is configured
+                        if (allowedEmailDomain) {
+                            const emailDomain = user.email.split('@')[1]?.toLowerCase()
+                            if (emailDomain !== allowedEmailDomain.toLowerCase()) {
+                                throw new Error(`Only emails from @${allowedEmailDomain} are allowed`)
+                            }
+                        }
+
+                        return { data: user }
+                    }
+                }
+            }
         }
     })
+}
+
+// Helper to get env var from Cloudflare Env (which may include secrets not in the type)
+function getEnvVar(env: Env, key: string): string | undefined {
+    return (env as unknown as Record<string, string | undefined>)[key]
+}
+
+export function isGoogleEnabled(env: Env): boolean {
+    return Boolean(getEnvVar(env, 'GOOGLE_CLIENT_ID') && getEnvVar(env, 'GOOGLE_CLIENT_SECRET'))
+}
+
+export function isMultiUserEnabled(env: Env): boolean {
+    const value = getEnvVar(env, 'MULTI_USER_ENABLED')
+    return value?.toLowerCase() === 'true'
+}
+
+export function isPasswordAuthEnabled(env: Env): boolean {
+    const value = getEnvVar(env, 'PASSWORD_AUTH_ENABLED')
+    // Default to true if not set
+    return value?.toLowerCase() !== 'false'
+}
+
+export function getAllowedEmailDomain(env: Env): string | undefined {
+    const value = getEnvVar(env, 'ALLOWED_EMAIL_DOMAIN')
+    return value || undefined
+}
+
+export function getGoogleClientId(env: Env): string | undefined {
+    return getEnvVar(env, 'GOOGLE_CLIENT_ID')
+}
+
+export function getGoogleClientSecret(env: Env): string | undefined {
+    return getEnvVar(env, 'GOOGLE_CLIENT_SECRET')
 }
 
 export async function getUserCount({ database }: { database: D1Database }): Promise<number> {

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,6 +1,6 @@
-import { Form, redirect, useActionData, useNavigation } from "react-router";
+import { Form, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
 import type { Route } from "./+types/login";
-import { getAuth, getUserCount } from "#/lib/auth.server";
+import { getAuth, getUserCount, isGoogleEnabled, isPasswordAuthEnabled } from "#/lib/auth.server";
 import { Button } from "#/components/ui/button";
 import { Input } from "#/components/ui/input";
 import { Label } from "#/components/ui/label";
@@ -14,7 +14,8 @@ export const meta: Route.MetaFunction = () => {
 };
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const database = context.cloudflare.env.DB;
+  const env = context.cloudflare.env;
+  const database = env.DB;
   const auth = getAuth({ database });
 
   // Redirect to app if already logged in
@@ -31,11 +32,28 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       return redirect("/signup");
   }
 
-  return {};
+  return {
+    googleEnabled: isGoogleEnabled(env),
+    passwordAuthEnabled: isPasswordAuthEnabled(env),
+  };
 }
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const formData = await request.formData();
+  const action = formData.get("action") as string;
+
+  if (action === "google") {
+    try {
+      await authClient.signIn.social({
+        provider: "google",
+        callbackURL: "/forms"
+      });
+      return null;
+    } catch (err) {
+      return { error: "Failed to initiate Google sign in. Please try again." };
+    }
+  }
+
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
 
@@ -57,10 +75,36 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   }
 }
 
+function GoogleIcon() {
+  return (
+    <svg className="h-5 w-5" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="currentColor"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  );
+}
+
 export default function Login() {
+  const loaderData = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof clientAction>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
+  const googleEnabled = loaderData?.googleEnabled ?? false;
+  const passwordAuthEnabled = loaderData?.passwordAuthEnabled ?? true;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
@@ -72,45 +116,81 @@ export default function Login() {
           </p>
         </div>
 
-        <Form method="post" className="space-y-6">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                required
-                placeholder="you@example.com"
-                autoComplete="email"
-                disabled={isSubmitting}
-              />
-            </div>
+        {googleEnabled && (
+          <Form method="post">
+            <input type="hidden" name="action" value="google" />
+            <Button
+              type="submit"
+              variant="outline"
+              className="w-full"
+              disabled={isSubmitting}
+            >
+              <GoogleIcon />
+              <span className="ml-2">Continue with Google</span>
+            </Button>
+          </Form>
+        )}
 
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                name="password"
-                type="password"
-                required
-                placeholder="Your password"
-                autoComplete="current-password"
-                disabled={isSubmitting}
-              />
+        {googleEnabled && passwordAuthEnabled && (
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-background px-2 text-muted-foreground">
+                Or continue with email
+              </span>
             </div>
           </div>
+        )}
 
-          {actionData?.error && (
-            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              {actionData.error}
+        {passwordAuthEnabled && (
+          <Form method="post" className="space-y-6">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  required
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  required
+                  placeholder="Your password"
+                  autoComplete="current-password"
+                  disabled={isSubmitting}
+                />
+              </div>
             </div>
-          )}
 
-          <Button type="submit" className="w-full" disabled={isSubmitting}>
-            {isSubmitting ? "Signing In..." : "Sign In"}
-          </Button>
-        </Form>
+            {actionData?.error && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {actionData.error}
+              </div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? "Signing In..." : "Sign In"}
+            </Button>
+          </Form>
+        )}
+
+        {!googleEnabled && !passwordAuthEnabled && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            No authentication methods are configured. Please contact the administrator.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,6 +1,6 @@
-import { Form, redirect, useActionData, useNavigation } from "react-router";
+import { Form, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
 import type { Route } from "./+types/signup";
-import { getAuth, getUserCount } from "#/lib/auth.server";
+import { getAuth, getUserCount, isGoogleEnabled, isMultiUserEnabled, isPasswordAuthEnabled } from "#/lib/auth.server";
 import { Button } from "#/components/ui/button";
 import { Input } from "#/components/ui/input";
 import { Label } from "#/components/ui/label";
@@ -14,7 +14,8 @@ export const meta: Route.MetaFunction = () => {
 };
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  const database = context.cloudflare.env.DB;
+  const env = context.cloudflare.env;
+  const database = env.DB;
   const auth = getAuth({ database });
 
   // Redirect to app if already logged in
@@ -25,17 +26,37 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     return redirect("/forms");
   }
 
-  // Redirect to login if users already exist
   const userCount = await getUserCount({ database });
-  if (userCount > 0) {
+  const multiUserEnabled = isMultiUserEnabled(env);
+
+  // Redirect to login if users already exist and multi-user is disabled
+  if (userCount > 0 && !multiUserEnabled) {
     return redirect("/login");
   }
 
-  return {};
+  return {
+    googleEnabled: isGoogleEnabled(env),
+    passwordAuthEnabled: isPasswordAuthEnabled(env),
+    isFirstUser: userCount === 0,
+  };
 }
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const formData = await request.formData();
+  const action = formData.get("action") as string;
+
+  if (action === "google") {
+    try {
+      await authClient.signIn.social({
+        provider: "google",
+        callbackURL: "/forms"
+      });
+      return null;
+    } catch (err) {
+      return { error: "Failed to initiate Google sign in. Please try again." };
+    }
+  }
+
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
   const confirmPassword = formData.get("confirmPassword") as string;
@@ -65,10 +86,37 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   }
 }
 
+function GoogleIcon() {
+  return (
+    <svg className="h-5 w-5" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="currentColor"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="currentColor"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  );
+}
+
 export default function Signup() {
+  const loaderData = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof clientAction>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
+  const googleEnabled = loaderData?.googleEnabled ?? false;
+  const passwordAuthEnabled = loaderData?.passwordAuthEnabled ?? true;
+  const isFirstUser = loaderData?.isFirstUser ?? true;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
@@ -76,81 +124,120 @@ export default function Signup() {
         <div className="text-center">
           <h1 className="text-3xl font-bold">Welcome to FormZero</h1>
           <p className="mt-2 text-muted-foreground">
-            Create your account to get started
+            {isFirstUser
+              ? "Create your account to get started"
+              : "Create an account to join"
+            }
           </p>
         </div>
 
-        <Form method="post" className="space-y-6">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                name="name"
-                type="text"
-                required
-                placeholder="Your name"
-                autoComplete="name"
-                disabled={isSubmitting}
-              />
-            </div>
+        {googleEnabled && (
+          <Form method="post">
+            <input type="hidden" name="action" value="google" />
+            <Button
+              type="submit"
+              variant="outline"
+              className="w-full"
+              disabled={isSubmitting}
+            >
+              <GoogleIcon />
+              <span className="ml-2">Continue with Google</span>
+            </Button>
+          </Form>
+        )}
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                required
-                placeholder="you@example.com"
-                autoComplete="email"
-                disabled={isSubmitting}
-              />
+        {googleEnabled && passwordAuthEnabled && (
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
             </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                name="password"
-                type="password"
-                required
-                placeholder="At least 8 characters"
-                minLength={8}
-                autoComplete="new-password"
-                disabled={isSubmitting}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">Confirm Password</Label>
-              <Input
-                id="confirmPassword"
-                name="confirmPassword"
-                type="password"
-                required
-                placeholder="Re-enter your password"
-                minLength={8}
-                autoComplete="new-password"
-                disabled={isSubmitting}
-              />
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-background px-2 text-muted-foreground">
+                Or continue with email
+              </span>
             </div>
           </div>
+        )}
 
-          <div className="rounded-md bg-muted p-3 text-sm text-muted-foreground">
-            <strong>Important:</strong> Please remember your password. Password recovery is not available yet.
-          </div>
+        {passwordAuthEnabled && (
+          <Form method="post" className="space-y-6">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">Name</Label>
+                <Input
+                  id="name"
+                  name="name"
+                  type="text"
+                  required
+                  placeholder="Your name"
+                  autoComplete="name"
+                  disabled={isSubmitting}
+                />
+              </div>
 
-          {actionData?.error && (
-            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              {actionData.error}
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  required
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  required
+                  placeholder="At least 8 characters"
+                  minLength={8}
+                  autoComplete="new-password"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">Confirm Password</Label>
+                <Input
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  type="password"
+                  required
+                  placeholder="Re-enter your password"
+                  minLength={8}
+                  autoComplete="new-password"
+                  disabled={isSubmitting}
+                />
+              </div>
             </div>
-          )}
 
-          <Button type="submit" className="w-full" disabled={isSubmitting}>
-            {isSubmitting ? "Creating Account..." : "Create Account"}
-          </Button>
-        </Form>
+            <div className="rounded-md bg-muted p-3 text-sm text-muted-foreground">
+              <strong>Important:</strong> Please remember your password. Password recovery is not available yet.
+            </div>
+
+            {actionData?.error && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {actionData.error}
+              </div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? "Creating Account..." : "Create Account"}
+            </Button>
+          </Form>
+        )}
+
+        {!googleEnabled && !passwordAuthEnabled && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            No authentication methods are configured. Please contact the administrator.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -66,6 +66,21 @@
 		"bindings": {
 			"BETTER_AUTH_SECRET": {
 				"description": "Secret for authentication system. Use https://jwtsecrets.com or `openssl rand -hex 16` to generate a secure secret (32 characters). No need to remember it"
+			},
+			"GOOGLE_CLIENT_ID": {
+				"description": "(Optional) Google OAuth Client ID from Google Cloud Console. Leave empty to disable Google login"
+			},
+			"GOOGLE_CLIENT_SECRET": {
+				"description": "(Optional) Google OAuth Client Secret from Google Cloud Console. Required if GOOGLE_CLIENT_ID is set"
+			},
+			"ALLOWED_EMAIL_DOMAIN": {
+				"description": "(Optional) Restrict login to emails from this domain (e.g., 'example.com'). Leave empty to allow any domain"
+			},
+			"MULTI_USER_ENABLED": {
+				"description": "(Optional) Set to 'true' to allow multiple users to sign up. Default: 'false' (single user mode)"
+			},
+			"PASSWORD_AUTH_ENABLED": {
+				"description": "(Optional) Set to 'false' to disable email/password authentication (Google OAuth only). Default: 'true'"
 			}
 		}
 	}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,5 +15,9 @@
 			"database_name": "formzero",
 			"database_id": "4a765081-eab0-424f-984b-e9b638a16de4",
 		}
-	]
+	],
+	"vars": {
+		"MULTI_USER_ENABLED": "false",
+		"PASSWORD_AUTH_ENABLED": "true"
+	}
 }


### PR DESCRIPTION
## Summary

Adds Google OAuth login with optional domain restriction and multi-user support.

- Google sign-in via Better-Auth
- Restrict sign-up to specific email domains (e.g., `@acme.com`)
- Toggle between single-user and multi-user mode
- Disable password auth entirely for Google-only setups

## New environment variables

**Secrets** (Cloudflare dashboard or `.dev.vars`):
- `GOOGLE_CLIENT_ID` — from Google Cloud Console
- `GOOGLE_CLIENT_SECRET` — from Google Cloud Console
- `ALLOWED_EMAIL_DOMAIN` — restrict to a domain (optional)

**Public vars** (`wrangler.jsonc`):
- `MULTI_USER_ENABLED` — allow multiple users (default: `false`)
- `PASSWORD_AUTH_ENABLED` — enable email/password (default: `true`)

## Why this matters

Domain restriction only works securely with Google OAuth since email/password doesn't verify ownership. For teams wanting strict domain enforcement, the recommended setup is:

```
GOOGLE_CLIENT_ID="..."
GOOGLE_CLIENT_SECRET="..."
ALLOWED_EMAIL_DOMAIN="yourcompany.com"
MULTI_USER_ENABLED="true"
PASSWORD_AUTH_ENABLED="false"
```

## Docs

README includes step-by-step Google Cloud Console setup instructions.

## Test plan

- [ ] Email/password login still works when `PASSWORD_AUTH_ENABLED=true`
- [ ] Google OAuth flow works with valid credentials
- [ ] Domain restriction blocks users from wrong domains
- [ ] Single-user mode blocks new sign-ups (both email and Google)
- [ ] Disabling password auth hides the email/password form