### PR TITLE
feat: delete submissions from the dashboard

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -10,6 +10,7 @@ export default [
   route("/forms", "routes/forms.tsx", [
     route(":formId", "routes/forms.$formId.tsx", [
       route("submissions", "routes/forms.$formId.submissions.tsx"),
+      route("submissions/:submissionId", "routes/forms.$formId.submissions.$submissionId.tsx"),
       route("integration", "routes/forms.$formId.integration.tsx"),
     ]),
   ]),

--- a/app/routes/forms.$formId.submissions.$submissionId.tsx
+++ b/app/routes/forms.$formId.submissions.$submissionId.tsx
@@ -1,0 +1,40 @@
+import type { Route } from "./+types/forms.$formId.submissions.$submissionId"
+import { data } from "react-router"
+import { requireAuth } from "~/lib/require-auth.server"
+
+export async function action({ request, params, context }: Route.ActionArgs) {
+  const database = context.cloudflare.env.DB
+
+  await requireAuth(request, database)
+
+  if (request.method !== "DELETE") {
+    return data(
+      { success: false, error: "Method not allowed" },
+      { status: 405 }
+    )
+  }
+
+  const { formId, submissionId } = params
+
+  try {
+    const result = await database
+      .prepare("DELETE FROM submissions WHERE id = ? AND form_id = ?")
+      .bind(submissionId, formId)
+      .run()
+
+    if (result.meta.changes === 0) {
+      return data(
+        { success: false, error: "Submission not found" },
+        { status: 404 }
+      )
+    }
+
+    return data({ success: true }, { status: 200 })
+  } catch (error) {
+    console.error("Error deleting submission:", error)
+    return data(
+      { success: false, error: "Failed to delete submission" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/routes/forms.$formId.submissions.tsx
+++ b/app/routes/forms.$formId.submissions.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { Link, useLoaderData } from "react-router"
 import type { Route } from "./+types/forms.$formId.submissions"
 import { createColumns } from "./forms.$formId.submissions/columns"
@@ -105,7 +106,7 @@ export default function SubmissionsPage() {
   const { submissions, stats, chartData } = useLoaderData<typeof loader>()
 
   // Generate columns based on submission data
-  const columns = createColumns(submissions)
+  const columns = useMemo(() => createColumns(submissions), [submissions])
 
   const exportToCSV = () => {
     if (submissions.length === 0) return

--- a/app/routes/forms.$formId.submissions/columns.tsx
+++ b/app/routes/forms.$formId.submissions/columns.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react"
 import type { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown } from "lucide-react"
+import { useFetcher } from "react-router"
+import { ArrowUpDown, Trash2, Loader2 } from "lucide-react"
 import { formatDistanceToNow } from "date-fns"
 import { Button } from "#/components/ui/button"
 import {
@@ -8,12 +10,80 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "#/components/ui/tooltip"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "#/components/ui/dialog"
 
 export type Submission = {
   id: string
   form_id: string
   data: Record<string, any>
   created_at: number
+}
+
+function DeleteSubmissionButton({ submission }: { submission: Submission }) {
+  const fetcher = useFetcher()
+  const [open, setOpen] = useState(false)
+  const isDeleting = fetcher.state !== "idle"
+
+  const handleDelete = () => {
+    fetcher.submit(null, {
+      method: "delete",
+      action: `/forms/${submission.form_id}/submissions/${submission.id}`,
+    })
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+        onClick={() => setOpen(true)}
+        aria-label="Delete submission"
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+      <Dialog open={open} onOpenChange={(next) => !isDeleting && setOpen(next)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete submission?</DialogTitle>
+            <DialogDescription>
+              This permanently removes the submission and its data. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                "Delete"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
 }
 
 export function createColumns(submissions: Submission[]): ColumnDef<Submission>[] {
@@ -108,5 +178,15 @@ export function createColumns(submissions: Submission[]): ColumnDef<Submission>[
     }
   })
 
-  return [timeColumn, ...dataColumns]
+  const actionsColumn: ColumnDef<Submission> = {
+    id: "actions",
+    header: "",
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <DeleteSubmissionButton submission={row.original} />
+      </div>
+    ),
+  }
+
+  return [timeColumn, ...dataColumns, actionsColumn]
 }


### PR DESCRIPTION
Closes #5

## Summary
- Adds a trash icon on each row of the submissions table; clicking it opens a confirmation dialog and permanently removes the submission on confirm.
- New action-only route `forms/:formId/submissions/:submissionId` handles DELETE (guarded by `requireAuth`, mirrors the pattern from `settings.notifications`).
- `createColumns` is now memoized in the submissions page — without this, every parent render remounted the dialog and swallowed its open state.

## Security
- `requireAuth` on the action.
- Prepared statement with `.bind()` — no injection surface.
- `WHERE id = ? AND form_id = ?` prevents cross-form deletion even if a valid submission id is supplied under the wrong form.
- Rejects anything other than DELETE.

## Test plan
- [x] Trash icon renders on every row; dialog opens with Cancel/Delete and the correct copy.
- [x] Confirming a delete removes the row from the UI (102 → 101) and from the D1 table; no full page reload.
- [x] Unauthenticated DELETE → 302 to `/login` (row remains in DB).
- [x] Authenticated DELETE with a mismatched `formId` → 404, row remains in DB.
- [x] `npm run typecheck` passes.