### PR TITLE
feat: rename and delete a form from a Settings tab

### DIFF
--- a/app/components/form-nav.tsx
+++ b/app/components/form-nav.tsx
@@ -1,4 +1,4 @@
-import { Database, Puzzle } from "lucide-react"
+import { Database, Puzzle, Settings } from "lucide-react"
 import { NavLink, useParams } from "react-router"
 
 import {
@@ -27,6 +27,11 @@ export function FormNav() {
       title: "Integration",
       url: `/forms/${formId}/integration`,
       icon: Puzzle,
+    },
+    {
+      title: "Settings",
+      url: `/forms/${formId}/settings`,
+      icon: Settings,
     },
   ]
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -10,6 +10,7 @@ export default [
   route("/forms", "routes/forms.tsx", [
     route(":formId", "routes/forms.$formId.tsx", [
       route("submissions", "routes/forms.$formId.submissions.tsx"),
+      route("submissions/:submissionId", "routes/forms.$formId.submissions.$submissionId.tsx"),
       route("integration", "routes/forms.$formId.integration.tsx"),
     ]),
   ]),

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,7 @@ export default [
       route("submissions", "routes/forms.$formId.submissions.tsx"),
       route("submissions/:submissionId", "routes/forms.$formId.submissions.$submissionId.tsx"),
       route("integration", "routes/forms.$formId.integration.tsx"),
+      route("settings", "routes/forms.$formId.settings.tsx"),
     ]),
   ]),
   route("settings/notifications", "routes/settings.notifications.tsx"),

--- a/app/routes/forms.$formId.settings.tsx
+++ b/app/routes/forms.$formId.settings.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useState } from "react"
+import { data, redirect, useFetcher, useLoaderData } from "react-router"
+import type { Route } from "./+types/forms.$formId.settings"
+import type { Form } from "#/types/form"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "#/components/ui/card"
+import { Input } from "#/components/ui/input"
+import { Label } from "#/components/ui/label"
+import { Button } from "#/components/ui/button"
+import { ResultButton } from "#/components/result-button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "#/components/ui/dialog"
+import { Loader2 } from "lucide-react"
+import { requireAuth } from "~/lib/require-auth.server"
+
+export const meta: Route.MetaFunction = () => {
+  return [
+    { title: "Settings | FormZero" },
+    { name: "description", content: "Manage your form settings" },
+  ]
+}
+
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const database = context.cloudflare.env.DB
+
+  await requireAuth(request, database)
+
+  const form = await database
+    .prepare("SELECT id, name FROM forms WHERE id = ?")
+    .bind(params.formId)
+    .first<Form>()
+
+  if (!form) {
+    throw new Response("Form not found", { status: 404 })
+  }
+
+  return { form }
+}
+
+export async function action({ request, params, context }: Route.ActionArgs) {
+  const database = context.cloudflare.env.DB
+
+  await requireAuth(request, database)
+
+  const { formId } = params
+
+  if (request.method === "DELETE") {
+    try {
+      const result = await database
+        .prepare("DELETE FROM forms WHERE id = ?")
+        .bind(formId)
+        .run()
+
+      if (result.meta.changes === 0) {
+        return data(
+          { success: false, error: "Form not found" },
+          { status: 404 }
+        )
+      }
+
+      return redirect("/forms")
+    } catch (error) {
+      console.error("Error deleting form:", error)
+      return data(
+        { success: false, error: "Failed to delete form" },
+        { status: 500 }
+      )
+    }
+  }
+
+  if (request.method !== "POST") {
+    return data(
+      { success: false, error: "Method not allowed" },
+      { status: 405 }
+    )
+  }
+
+  try {
+    const formData = await request.formData()
+    const name = (formData.get("name") as string | null)?.trim()
+
+    if (!name) {
+      return data(
+        { success: false, error: "Form name is required" },
+        { status: 400 }
+      )
+    }
+
+    const result = await database
+      .prepare("UPDATE forms SET name = ?, updated_at = ? WHERE id = ?")
+      .bind(name, Date.now(), formId)
+      .run()
+
+    if (result.meta.changes === 0) {
+      return data(
+        { success: false, error: "Form not found" },
+        { status: 404 }
+      )
+    }
+
+    return data({ success: true }, { status: 200 })
+  } catch (error) {
+    console.error("Error updating form:", error)
+    return data(
+      { success: false, error: "Failed to update form" },
+      { status: 500 }
+    )
+  }
+}
+
+export default function FormSettings() {
+  const { form } = useLoaderData<typeof loader>()
+  const updateFetcher = useFetcher<{ success?: boolean; error?: string }>()
+  const deleteFetcher = useFetcher<{ success?: boolean; error?: string }>()
+
+  const [name, setName] = useState(form.name)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [confirmText, setConfirmText] = useState("")
+
+  useEffect(() => {
+    setName(form.name)
+  }, [form.name])
+
+  const isSaving = updateFetcher.state === "submitting"
+  const isSaved = updateFetcher.state === "idle" && updateFetcher.data?.success === true
+  const updateError =
+    updateFetcher.state === "idle" && updateFetcher.data?.error
+      ? updateFetcher.data.error
+      : null
+
+  const isDeleting = deleteFetcher.state !== "idle"
+
+  const handleDelete = () => {
+    deleteFetcher.submit(null, {
+      method: "delete",
+      action: `/forms/${form.id}/settings`,
+    })
+  }
+
+  const canSave = name.trim().length > 0 && name.trim() !== form.name
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 min-w-0 max-w-2xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Form Name</CardTitle>
+          <CardDescription>
+            Used in the dashboard and in email notifications. Changing the name does not change
+            the form&apos;s URL.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <updateFetcher.Form
+            method="post"
+            action={`/forms/${form.id}/settings`}
+            className="space-y-4"
+          >
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                name="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+              {updateError && (
+                <p className="text-sm text-destructive">{updateError}</p>
+              )}
+            </div>
+            <ResultButton
+              type="submit"
+              isSubmitting={isSaving}
+              isSuccess={isSaved}
+              loadingText="Saving..."
+              successText="Saved!"
+              disabled={!canSave}
+            >
+              Save
+            </ResultButton>
+          </updateFetcher.Form>
+        </CardContent>
+      </Card>
+
+      <Card className="border-destructive/50">
+        <CardHeader>
+          <CardTitle>Danger Zone</CardTitle>
+          <CardDescription>
+            Deleting this form permanently removes it and every submission it has received.
+            This action cannot be undone.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              setConfirmText("")
+              setDeleteOpen(true)
+            }}
+          >
+            Delete Form
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={deleteOpen}
+        onOpenChange={(next) => !isDeleting && setDeleteOpen(next)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete &ldquo;{form.name}&rdquo;?</DialogTitle>
+            <DialogDescription>
+              This permanently removes the form and all of its submissions. Type the form name
+              below to confirm.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="confirm">Form name</Label>
+            <Input
+              id="confirm"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={form.name}
+              autoComplete="off"
+            />
+            {deleteFetcher.data?.error && (
+              <p className="text-sm text-destructive">{deleteFetcher.data.error}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteOpen(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isDeleting || confirmText !== form.name}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                "Delete Form"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/routes/forms.$formId.submissions.$submissionId.tsx
+++ b/app/routes/forms.$formId.submissions.$submissionId.tsx
@@ -1,0 +1,40 @@
+import type { Route } from "./+types/forms.$formId.submissions.$submissionId"
+import { data } from "react-router"
+import { requireAuth } from "~/lib/require-auth.server"
+
+export async function action({ request, params, context }: Route.ActionArgs) {
+  const database = context.cloudflare.env.DB
+
+  await requireAuth(request, database)
+
+  if (request.method !== "DELETE") {
+    return data(
+      { success: false, error: "Method not allowed" },
+      { status: 405 }
+    )
+  }
+
+  const { formId, submissionId } = params
+
+  try {
+    const result = await database
+      .prepare("DELETE FROM submissions WHERE id = ? AND form_id = ?")
+      .bind(submissionId, formId)
+      .run()
+
+    if (result.meta.changes === 0) {
+      return data(
+        { success: false, error: "Submission not found" },
+        { status: 404 }
+      )
+    }
+
+    return data({ success: true }, { status: 200 })
+  } catch (error) {
+    console.error("Error deleting submission:", error)
+    return data(
+      { success: false, error: "Failed to delete submission" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/routes/forms.$formId.submissions.tsx
+++ b/app/routes/forms.$formId.submissions.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { Link, useLoaderData } from "react-router"
 import type { Route } from "./+types/forms.$formId.submissions"
 import { createColumns } from "./forms.$formId.submissions/columns"
@@ -105,7 +106,7 @@ export default function SubmissionsPage() {
   const { submissions, stats, chartData } = useLoaderData<typeof loader>()
 
   // Generate columns based on submission data
-  const columns = createColumns(submissions)
+  const columns = useMemo(() => createColumns(submissions), [submissions])
 
   const exportToCSV = () => {
     if (submissions.length === 0) return

--- a/app/routes/forms.$formId.submissions/columns.tsx
+++ b/app/routes/forms.$formId.submissions/columns.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react"
 import type { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown } from "lucide-react"
+import { useFetcher } from "react-router"
+import { ArrowUpDown, Trash2, Loader2 } from "lucide-react"
 import { formatDistanceToNow } from "date-fns"
 import { Button } from "#/components/ui/button"
 import {
@@ -8,12 +10,80 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "#/components/ui/tooltip"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "#/components/ui/dialog"
 
 export type Submission = {
   id: string
   form_id: string
   data: Record<string, any>
   created_at: number
+}
+
+function DeleteSubmissionButton({ submission }: { submission: Submission }) {
+  const fetcher = useFetcher()
+  const [open, setOpen] = useState(false)
+  const isDeleting = fetcher.state !== "idle"
+
+  const handleDelete = () => {
+    fetcher.submit(null, {
+      method: "delete",
+      action: `/forms/${submission.form_id}/submissions/${submission.id}`,
+    })
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+        onClick={() => setOpen(true)}
+        aria-label="Delete submission"
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+      <Dialog open={open} onOpenChange={(next) => !isDeleting && setOpen(next)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete submission?</DialogTitle>
+            <DialogDescription>
+              This permanently removes the submission and its data. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                "Delete"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
 }
 
 export function createColumns(submissions: Submission[]): ColumnDef<Submission>[] {
@@ -108,5 +178,15 @@ export function createColumns(submissions: Submission[]): ColumnDef<Submission>[
     }
   })
 
-  return [timeColumn, ...dataColumns]
+  const actionsColumn: ColumnDef<Submission> = {
+    id: "actions",
+    header: "",
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <DeleteSubmissionButton submission={row.original} />
+      </div>
+    ),
+  }
+
+  return [timeColumn, ...dataColumns, actionsColumn]
 }


### PR DESCRIPTION
Closes #6

## Summary
- New **Settings** tab per form at `/forms/:formId/settings`, added alongside Submissions and Integration in the sidebar nav.
- **Rename**: update the form's display name. The form's `id` (and therefore its integration URL) stays stable so existing submission endpoints keep working.
- **Delete**: permanently removes the form and cascades all its submissions (via the existing FK). Type-to-confirm — the user must type the form name before the destructive button activates. On success, redirects to `/forms`, which routes to the first remaining form or `/setup` when none remain.

## Method choice (POST vs PUT)
Stuck with `POST` for update to match the rest of the codebase (`settings.notifications`, `forms`). The action handles `POST` (update) and `DELETE` (delete); other methods return 405. The update handler is written so additional fields can be added later without changing the method.

## Security
- `requireAuth` on both loader and action.
- All queries are prepared with `.bind()`.
- Method gate rejects anything other than `POST`/`DELETE`.
- Empty names return 400.
- Missing form on update returns 404.

## Test plan
- [x] Rename: changed "Test Contact Form" → "Renamed Contact Form" via the UI; sidebar and DB updated immediately; id (`test-form-1`) unchanged.
- [x] Delete: created throwaway form with one submission, deleted via the UI with type-to-confirm; redirected to remaining form; DB confirms the form and its submission are gone (cascade).
- [x] Save button disabled when name is unchanged or empty.
- [x] Delete button disabled until the typed name matches.
- [x] Unauthenticated `GET`/`POST`/`DELETE` → 302 to `/login`.
- [x] Authenticated `PUT` → 405.
- [x] Authenticated `POST` with empty name → 400.
- [x] Authenticated update on non-existent form → 404.
- [x] `npm run typecheck` passes.